### PR TITLE
Added activation steps of Jetbrains for Windows

### DIFF
--- a/src/content/jetbrains/index.html
+++ b/src/content/jetbrains/index.html
@@ -20,13 +20,22 @@ icon_height: 150
 	<h4>Install manually</h4>
 	<p>Download using the <a href="https://github.com/dracula/jetbrains/archive/master.zip">GitHub .zip download</a> option and unzip them</p>
 
-	<h4>Activating theme</h4>
-    <ol>
-        <li>Create a folder called <code>colors</code> inside <code>~/Library/Preferences/<b>{NameOfIDE}</b></code>.</li>
-        <li>Copy the <code>./jetbrains/Dracula.icls</code> file to the <code>~/Library/Preferences/<b>{NameOfIDE}</b>/colors</code> directory on your local machine.</li>
-        <li>Close and re-open <b>{NameOfIDE}</b>.</li>
-        <li>Navigate to <code><b>{NameOfIDE}</b> -> Preferences -> Editor -> Colors & Fonts</code>.</li>
-        <li>Select “Dracula” from the dropdown menu.</li>
-        <li>Click the “Ok” button to activate the color scheme.</li>
-    </ol>
+	<h4>Activating theme on Mac</h4>
+	    <ol>
+		<li>Create a folder called <code>colors</code> inside <code>~/Library/Preferences/<b>{NameOfIDE}</b></code>.</li>
+		<li>Copy the <code>./jetbrains/Dracula.icls</code> file to the <code>~/Library/Preferences/<b>{NameOfIDE}</b>/colors</code> directory on your local machine.</li>
+		<li>Close and re-open <b>{NameOfIDE}</b>.</li>
+		<li>Navigate to <code><b>{NameOfIDE}</b> -> Preferences -> Editor -> Colors & Fonts</code>.</li>
+		<li>Select “Dracula” from the dropdown menu.</li>
+		<li>Click the “Ok” button to activate the color scheme.</li>
+	    </ol>
+	<h4>Activating theme on Windows</h4>
+	    <ol>
+		<li>Create a folder called <code>colors</code> inside <code>%USERPROFILE%\<b>.IdeaICXX</b>\config</code>.</li>
+		<li>Copy the <code>.\jetbrains\Dracula.icls</code> file to the <code>%USERPROFILE%\<b>.IdeaICXX</b>\config\colors</code> directory on your local machine.</li>
+		<li>Close and re-open <b>{NameOfIDE}</b>.</li>
+		<li>Navigate to <code>File -> Settings -> Editor -> Colors & Fonts</code>.</li>
+		<li>Select “Dracula” from the dropdown menu.</li>
+		<li>Click the “Ok” button to activate the color scheme.</li>
+	    </ol>
 </div>


### PR DESCRIPTION
I splitted the activation steps of JetBrains for Windows and Mac, because It's a little different the location of folders for both SO. (I added the steps for Windows)