### PR TITLE
iTerm: Update instructions

### DIFF
--- a/src/content/iterm/index.html
+++ b/src/content/iterm/index.html
@@ -26,8 +26,8 @@ icon_height: 182
 
 	<ol>
 		<li><em>iTerm2 > Preferences > Profiles > Colors Tab</em></li>
-		<li>Click <em>Load Presets...</em></li>
-		<li>Click <em>Import...</em></li>
+		<li>Open the <em>Color Presets...</em> drop-down in the bottom right corner</li>
+		<li>Select <em>Import...</em> from the list</li>
 		<li>Select the <code>Dracula.itermcolors</code> file</li>
 		<li>Select the <em>Dracula</em> from <em>Load Presets...</em></li>
 	</ol>


### PR DESCRIPTION
Rename Load Presets to Color Presets to match the actual name of the drop-down to open.
Specify that you should look for a drop-down for Color Presets and where it is located.