### PR TITLE
Add optional installation instructions to emacs

### DIFF
--- a/src/content/emacs/index.html
+++ b/src/content/emacs/index.html
@@ -17,6 +17,10 @@ repo: emacs
 
 	<pre><code>M-x package-install &lt;RET&gt; dracula-theme</code></pre>
 
+	<h4>Install using Homebrew</h4>
+
+	<pre><code>brew install dunn/emacs/helm</code></pre>
+
 	<h4>Install manually</h4>
 
 	<p>Add the emacs theme files to <code>~/.emacs.d/themes</code>.</p>


### PR DESCRIPTION
As of dunn/homebrew-emacs@8d7b04b2d47a6591826e47769db49513835d0bc4 the emacs
version of the dracula theme can be installed via homebrew. This commit updates
the installation instructions to include this installation option.