### PR TITLE
Update install instructions for vscode

### DIFF
--- a/src/content/visual-studio-code/index.html
+++ b/src/content/visual-studio-code/index.html
@@ -26,11 +26,10 @@ repo: visual-studio-code
 
     <p>If you are a git user, you can install the theme and keep up to date by cloning the repo:</p>
 
-    <pre><code>$ git clone https://github.com/dracula/visual-studio-code.git ~/.vscode/extensions/theme-dracula</code></pre>
-
-    <h4>Install manually</h4>
-
-    <p>Download using the <a href="https://github.com/dracula/visual-studio-code/archive/master.zip">GitHub .zip download</a> option and unzip them.</p>
+    <pre><code>$ git clone https://github.com/dracula/visual-studio-code.git ~/.vscode/extensions/theme-dracula
+$ cd ~/.vscode/extensions/theme-dracula
+$ npm install
+$ npm run build</code></pre>
 
     <h4>Activating theme</h4>
 


### PR DESCRIPTION
The instructions for vscode are outdated (see dracula/visual-studio-code#16). This PR fixes that.