### PR TITLE
update npp instruction

### DIFF
--- a/src/content/notepad-plus-plus/index.html
+++ b/src/content/notepad-plus-plus/index.html
@@ -26,7 +26,7 @@ repo: notepad-plus-plus
 	<h4>Activating theme</h4>
 
 	<ol>
-		<li>Go to <code>%AppData%\Roaming\Notepad++\themes</code></li>
+		<li>Go to <code>%AppData%\Notepad++\themes</code></li>
 		<li>Place <code>Dracula.xml</code> inside that folder</li>
 		<li>Restart Notepad++</li>
 		<li>Dracula will be available in <code>Settings > Style Configurator</code></li>


### PR DESCRIPTION
"Roaming" extra-folder in activation instruction deleted