### PR TITLE
Use Moon logo instead of Dracula logo for Hyper theme

### DIFF
--- a/hyper/index.html
+++ b/hyper/index.html
@@ -25,7 +25,7 @@
 		<header class="header row center-xs">
 			<div class="col-xs-12">
 				<a href="../">
-					<img src="../assets/img/icons/dracula.png" width="168" height="176" alt="Hyper">
+					<img src="../assets/img/icons/moon.png" width="168" height="176" alt="Hyper">
 					<h1 class="title">Dracula</h1>
 				</a>
 				<h2 class="subtitle">A dark theme for Hyper <a href="../">and more</a></h2>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
 		</a>
 		<a href="./hyper/" class="app col-xs-12 col-sm-2">
 			<span class="app-img">
-				<img src="./assets/img/icons/dracula.png" width="168" height="176" alt="Dracula">
+				<img src="./assets/img/icons/moon.png" width="168" height="176" alt="Dracula">
 			</span>
 			<h3 class="app-title orange">Hyper</h3>
 		</a>


### PR DESCRIPTION
The Dracula logo is only used at the top of the page and looks a little out of
place as a theme logo. moon.png was used becuase it would be the next in the
cycle if we continued to use the same logos in the same order. This is probably
best for now until we get more logos