### PR TITLE
Support Xcode 8 or later

### DIFF
--- a/src/content/xcode/index.html
+++ b/src/content/xcode/index.html
@@ -24,8 +24,9 @@ repo: xcode
 
 	<p>And a symbolic link to this custom themes folder:</p>
 
-	<pre><code>$ ln -s $DRACULA_THEME/Dracula.dvtcolortheme ~/Library/Developer/Xcode/UserData/FontAndColorThemes/Dracula.dvtcolortheme</code></pre>
+	<pre><code>$ ln -s $DRACULA_THEME/Dracula.xccolortheme ~/Library/Developer/Xcode/UserData/FontAndColorThemes/Dracula.xccolortheme</code></pre>
 
+	<p><em>If you are using Xcode 7 or earlier, use <code>Dracula.dvtcolortheme</code> instead of <code>Dracula.xccolortheme</code></em></p>
 	<p><em>P.S.: Remember that you should replace <code>$DRACULA_THEME</code> with the
 	actual directory for this command to work.</em></p>
 
@@ -33,7 +34,7 @@ repo: xcode
 	<ol>
 		<li>Download using the <a href="https://github.com/dracula/xcode/archive/master.zip">GitHub .zip download</a> option and unzip them.</li>
 		<li>Create the custom themes folder: <code>~/Library/Developer/Xcode/UserData/FontAndColorThemes/</code></li>
-		<li>Move <code>Dracula.dvtcolortheme</code> file to this custom themes folder.</li>
+		<li>Move <code>Dracula.xccolortheme</code> file to this custom themes folder.</li>
 	</ol>
 
 	<h4>Activating theme</h4>


### PR DESCRIPTION
On latest Xcode (8 or later), color theme extension is modified to `xccolortheme`.
So it have to be `xccolortheme` instead of `dvtcolortheme`.

ref : Dracula/xcode#5