### PR TITLE
Added new Mac import settings and separated Linux

### DIFF
--- a/src/content/jetbrains/index.html
+++ b/src/content/jetbrains/index.html
@@ -11,35 +11,94 @@ repo: jetbrains
 <img class="preview" src="{{ baseurl }}/assets/img/screenshots/jetbrains.png" alt="Theme Preview" width="1000" height="700">
 
 <div class="instructions">
-	<h3><a href="http://www.jetbrains.com/">JetBrains</a></h3>
-	<p>This theme works with all JetBrains IDEs like IntelliJ, WebStorm, PyCharm, PhpStorm, etc.</p>
-	<p>Whenever you see a <b>{NameOfIDE}</b>, translate it to the IDE you're using.</p>
-    <p>Whenever you see a <b>{You}</b>, translate it to your username on your local machine.</p>
-	<h4>Install using Git</h4>
-	<p>If you are a git user, you can install the theme and keep up to date by cloning the repo:</p>
-	<pre><code>$ git clone https://github.com/dracula/jetbrains.git</code></pre>
+  <h3>
+    <a href="http://www.jetbrains.com/">JetBrains</a>
+  </h3>
+  <p>This theme works with all JetBrains IDEs like IntelliJ, WebStorm, PyCharm, PhpStorm, etc.</p>
+  <p>Whenever you see a
+    <b>{NameOfIDE}</b>, translate it to the IDE you're using.</p>
+  <p>Whenever you see a
+    <b>{You}</b>, translate it to your username on your local machine.</p>
+  <h4>Install using Git</h4>
+  <p>If you are a git user, you can install the theme and keep up to date by cloning the repo:</p>
+  <pre><code>$ git clone https://github.com/dracula/jetbrains.git</code></pre>
 
-	<h4>Install manually</h4>
-	<p>Download using the <a href="https://github.com/dracula/jetbrains/archive/master.zip">GitHub .zip download</a> option and unzip them</p>
+  <h4>Install manually</h4>
+  <p>Download using the
+    <a href="https://github.com/dracula/jetbrains/archive/master.zip">GitHub .zip download</a> option and unzip them</p>
 
-	<h4>Activating theme</h4>
+  <h4>Activating theme</h4>
+  <ol>
+    <li>
+      <b>Windows</b>
+    </li>
     <ol>
-        <li><b>Windows</b></li>
-        <ol>
-            <li>Create a folder called <code>colors</code> inside <code>C:/Users/<b>{you}</b>/.<b>{NameOfIDE}</b>/config/</code>.</li>
-            <li>Copy the <code>./jetbrains/Dracula.icls</code> file to the <code>C:/Users/<b>{you}</b>/.<b>{NameOfIDE}</b>/config/colors/</code> directory on your local machine.</li>
-        </ol>
-        <li><b>Mac/Linux</b><li>
-        <ol>
-            <li>Create a folder called <code>colors</code> inside <code>~/.<b>{NameOfIDE}</b>/config/</code>.</li>
-            <li>Copy the <code>./jetbrains/Dracula.icls</code> file to the <code>~/.<b>{NameOfIDE}</b>/config/colors/</code> directory on your local machine.</li>
-        </ol>
-        <li>Close and re-open <b>{NameOfIDE}</b>.</li>
-        <li>Close and re-open <b>{NameOfIDE}</b>.</li>
-        <li>Navigate to <code><b>{NameOfIDE}</b> -> Preferences -> Editor -> Colors & Fonts</code>.</li>
-        <li>Select “Dracula” from the dropdown menu.</li>
-        <li>Click the “Ok” button to activate the color scheme.</li>
+      <li>Create a folder called
+        <code>colors</code> inside
+        <code>C:/Users/<b>{you}</b>/.<b>{NameOfIDE}</b>/config/</code>.</li>
+      <li>Copy the
+        <code>./jetbrains/Dracula.icls</code> file to the
+        <code>C:/Users/<b>{you}</b>/.<b>{NameOfIDE}</b>/config/colors/</code> directory on your local machine.</li>
     </ol>
+    <li>
+      <b>Mac</b>
+    </li>
+    <li>
+      <i>Option 1</i>
+    </li>
+    <li>
+      <ol>
+        <li>Create a folder called
+          <code>colors</code> inside
+          <code>~/Library/Preferences/<b><PRODUCT><VERSION></b></code>.</li>
+        <li>Copy the
+          <code>./jetbrains/Dracula.icls</code> file to the
+          <code>~/Library/Preferences/<b><PRODUCT><VERSION></b>/colors/</code> directory on your local machine.</li>
+      </ol>
+      <li>Close and re-open
+        <b>{NameOfIDE}</b>.</li>
+      <li>Navigate to
+        <code><b>{NameOfIDE}</b> -> Preferences -> Editor -> Color Scheme</code>.</li>
+      <li>Select “Dracula” from the dropdown menu.</li>
+      <li>Click the “Ok” button to activate the color scheme.</li>
+    </li>
+    <li>
+      <i>Option 2</i>
+    </li>
+    <li>
+      <ol>
+        <li>Open {NameOfIDE} and navigate to
+          <code>Preferences -> Editor -> Color Scheme</code>.</li>
+        <li>Click the settings cog and
+          <code>Import Scheme...</code>.</li>
+        <li>Navigate to
+          <code>Dracula.icls</code> and apply changes.</li>
+      </ol>
+      <li>Close and re-open
+        <b>{NameOfIDE}</b>.</li>
+    </li>
+    <li>
+      <b>Linux</b>
+    </li>
+    <li>
+      <ol>
+        <li>Create a folder called
+          <code>colors</code> inside
+          <code>~/.<b>{NameOfIDE}</b>/config/</code>.</li>
+        <li>Copy the
+          <code>./jetbrains/Dracula.icls</code> file to the
+          <code>~/.<b>{NameOfIDE}</b>/config/colors/</code> directory on your local machine.</li>
+      </ol>
+      <li>Close and re-open
+        <b>{NameOfIDE}</b>.</li>
+      <li>Close and re-open
+        <b>{NameOfIDE}</b>.</li>
+      <li>Navigate to
+        <code><b>{NameOfIDE}</b> -> Preferences -> Editor -> Colors & Fonts</code>.</li>
+      <li>Select “Dracula” from the dropdown menu.</li>
+      <li>Click the “Ok” button to activate the color scheme.</li>
+    </li>
+  </ol>
 
-    {{> contributors contributors=jetbrains repo=repo }}
+  {{> contributors contributors=jetbrains repo=repo }}
 </div>


### PR DESCRIPTION
Due to the new changes with Mac and Linux versions of Jetbrains products, their directories are changed. I also added another way to add the syntax.

https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs