### PR TITLE
update 'hyper-dracula' installation instructions ('hpm' deprecated)

### DIFF
--- a/src/content/hyper/index.html
+++ b/src/content/hyper/index.html
@@ -13,9 +13,8 @@ repo: hyper
 <div class="instructions">
 	<h3><a href="https://hyper.is/">Hyper</a></h3>
 
-	<h4>Install using <a href="https://github.com/zeit/hpm">hpm</a></h4>
-	<p>Install via <code>hpm</code> command line:</p>
-	<pre><code>$ hpm install hyper-dracula</code></pre>
+	<h4>Install using the <a href="https://hyper.is/">hyper command-line interface</a></h4>
+	<pre><code>$ hyper install hyper-dracula</code></pre>
 
 	<h4>Install using config file</h4>
 	<p>Add <code>hyper-dracula</code> to the plugins list in your <code>~/.hyper.js</code> config file.</p>


### PR DESCRIPTION
`hpm` has been [deprecated](https://www.npmjs.com/package/hpm-cli) and replaced with the `hyper` CLI that comes with the app.

This patch updates the hyper-dracula installation instructions accordingly.