### PR TITLE
Add instruction to move `/lib` folder

### DIFF
--- a/src/content/zsh/index.html
+++ b/src/content/zsh/index.html
@@ -29,6 +29,7 @@ repo: zsh
 	<ol>
 		<li>Download using the <a href="https://github.com/dracula/zsh/archive/master.zip">GitHub .zip download</a> option and unzip them.</li>
 		<li>Move <code>dracula.zsh-theme</code> file to <a href="https://github.com/robbyrussell/oh-my-zsh/">oh-my-zsh</a>'s theme folder: <code>oh-my-zsh/themes/dracula.zsh-theme</code>.</li>
+		<li>Move <code>/lib</code> to <a href="https://github.com/robbyrussell/oh-my-zsh/">oh-my-zsh</a>'s theme folder: <code>oh-my-zsh/themes/lib</code>.</li>
 	</ol>
 
 	<h4>Activating theme</h4>


### PR DESCRIPTION
The instructions for manually installing are missing one key step. That is to move `/lib` to `~/.oh-my-zsh/themes`. If this step is not done, dracula theme does not work.

Fixes https://github.com/dracula/zsh/issues/11