### PR TITLE
Update Atom installation instructions

### DIFF
--- a/src/content/atom/index.html
+++ b/src/content/atom/index.html
@@ -18,17 +18,17 @@ repo: atom
 		<li>Go to <code>Atom -> Preferences...</code></li>
 		<li>Then select the <code>Install</code> tab</li>
 		<li>Click the <code>Themes</code> button to the right of the search box</li>
-		<li>Enter <code>dracula-theme</code> in the search box</li>
+		<li>Enter <code>dracula-syntax</code> in the search box</li>
 	</ol>
 
 	<h4>Install using Git</h4>
 	<p>Alternatively, if you are a git user, you can install the theme and keep up to date by cloning the repo directly into your <code>~/.atom/packages</code> directory.</p>
-	<pre><code>$ git clone https://github.com/dracula/atom.git ~/.atom/packages/dracula-theme</code></pre>
+	<pre><code>$ git clone https://github.com/dracula/atom.git ~/.atom/packages/dracula-syntax</code></pre>
 
 	<h4>Install manually</h4>
 	<ol>
 		<li>Download using the <a href="https://github.com/dracula/atom/archive/master.zip">GitHub .zip download</a> option and unzip them</li>
-		<li>Move the <code>dracula-theme</code> folder to <code>~/.atom/packages</code></li>
+		<li>Move the <code>dracula-syntax</code> folder to <code>~/.atom/packages</code></li>
 	</ol>
 
 	<h4>Activating theme</h4>


### PR DESCRIPTION
Commit https://github.com/dracula/atom/commit/65f093c78cf7da7d23e02ad37f5c545400c1e595 renamed dracula-theme to dracula-syntax. Information about the change was also added to the README: https://github.com/dracula/atom/commit/3ed7a498eb0a5756ead2707c28436acecd02fc7f. Resolves #95.