### PR TITLE
Added custom markdown renderer for codeblocks prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .next
 node_modules
 out
+
+#Jetbrains
+.idea

--- a/public/static/css/main.css
+++ b/public/static/css/main.css
@@ -184,6 +184,27 @@ pre {
 	overflow-wrap: break-word;
 }
 
+pre .prefixed {
+  white-space: normal;
+}
+
+pre .line {
+  list-style-type: none!important;
+}
+
+pre .line::before {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -o-user-select: none;
+  user-select: none;
+  content: attr(prefix);
+  text-align: right;
+  display: inline-block;
+  margin-right: 5px;
+  margin-left: 5px;
+}
+
 ol {
 	font-size: 1.1em;
 	font-weight: 300;


### PR DESCRIPTION
Fixes #72 

This is a first experiment with the custom Renderer from marked.js
The changes I did here will add the benefit that `$` will not be copied and make copy/pasting commands easier. There are no visual changes, it will look exactly the same.

Before:
![image](https://user-images.githubusercontent.com/11406433/72221375-82711800-355a-11ea-8a9a-fafd8d2c8a42.png)

After:
![image](https://user-images.githubusercontent.com/11406433/72221383-8ef57080-355a-11ea-9b18-d35781e1b0c4.png)

Of course this PR is open for feedback.